### PR TITLE
Sets the Ansible Galaxy role_name Variable

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,8 @@
 ---
 galaxy_info:
+  role_name: courier
   author: Ona Engineering
-  description: Installs and configures RapidPro
+  description: Installs and configures Courier. Courier is a messaging gateway for text-based messaging channels.
   company: Ona Systems Inc
   license: Apache v2.0
   min_ansible_version: 1.2

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -26,11 +26,11 @@ def test_courier_app_files(host):
     assert appVersionedDir.user == "courier"
     assert appVersionedDir.group == "courier"
     assert appVersionedDir.is_directory
-    assert oct(appVersionedDir.mode) == "0755"
+    assert oct(appVersionedDir.mode) == "0o755"
 
     envFile = host.file("/home/courier/app/environment")
     assert envFile.exists
     assert envFile.user == "courier"
     assert envFile.group == "courier"
     assert envFile.is_file
-    assert oct(envFile.mode) == "0750"
+    assert oct(envFile.mode) == "0o750"

--- a/templates/courier_active_package_symlink/environment.j2
+++ b/templates/courier_active_package_symlink/environment.j2
@@ -1,3 +1,3 @@
-{% for var_name,var_value in courier_environment_vars.iteritems() %}
+{% for var_name,var_value in courier_environment_vars.items() %}
 {{ var_name }}={{ var_value }}
 {% endfor %}


### PR DESCRIPTION
The role_name variable is set because Ansible Galaxy no longer applies a
regex on the repository name to remove 'ansible-' for the role name.

Fixes #2 

Signed-off-by: Jason Rogena <jason@rogena.me>